### PR TITLE
use v2 cache and devel in gha

### DIFF
--- a/.github/workflows/rworkflows.yml
+++ b/.github/workflows/rworkflows.yml
@@ -6,12 +6,16 @@ name: rworkflows
     - main
     - devel
     - RELEASE_**
+    - '*'
+    - '!gh-pages'
   pull_request:
     branches:
     - master
     - main
     - devel
     - RELEASE_**
+    - '*'
+    - '!gh-pages'
 jobs:
   rworkflows:
     permissions: write-all
@@ -23,17 +27,17 @@ jobs:
       matrix:
         config:
         - os: ubuntu-latest
-          bioc: devel 
+          bioc: devel
           r: auto
           cont: ghcr.io/bioconductor/bioconductor_docker:devel
           rspm: ~
         - os: macOS-latest
-          bioc: devel 
+          bioc: devel
           r: auto
           cont: ~
           rspm: ~
         - os: windows-latest
-          bioc: devel 
+          bioc: devel
           r: auto
           cont: ~
           rspm: ~
@@ -53,6 +57,5 @@ jobs:
         run_docker: ${{ false }}
         DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
         runner_os: ${{ runner.os }}
-        cache_version: cache-v1
+        cache_version: cache-v2
         docker_registry: ghcr.io
-        force_install: ${{ true }}


### PR DESCRIPTION
Build error now resolved : https://github.com/markrobinsonuzh/TreeSummarizedExperiment/commit/daaf32f4939c983ccc614f36b92953e3dc194c06

- Restored builds for devel
- Run gha on all PR
- Use cache v2 for gha